### PR TITLE
[main <- dev]💡 PR Summary - :recycle: 팀 생성 로직 변경(초대 없이 팀 구성)

### DIFF
--- a/src/main/java/com/b5f1/atention/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/b5f1/atention/domain/team/service/TeamServiceImpl.java
@@ -64,7 +64,12 @@ public class TeamServiceImpl implements TeamService {
         User hostUser = findUserById(userId);
         teamParticipantRepository.save(new TeamParticipant().createTeamParticipant(hostUser, team, true));
 
-        inviteUser(userId, team, teamCreateRequestDto);
+        // 강제 초대로 로직 변경
+        for (UUID invitedUserId : teamCreateRequestDto.getUserIdList()) {
+            User invitedUser = findUserById(invitedUserId);
+            teamParticipantRepository.save(new TeamParticipant().createTeamParticipant(invitedUser, team, false));
+        }
+//        inviteUser(userId, team, teamCreateRequestDto);
     }
 
     /**

--- a/src/test/java/com/b5f1/atention/domain/Team/TeamTests.java
+++ b/src/test/java/com/b5f1/atention/domain/Team/TeamTests.java
@@ -99,6 +99,8 @@ public class TeamTests {
         //then
         Optional<TeamParticipant> teamParticipant = teamParticipantRepository.findByUser(hostUser);
         assertThat(teamParticipant).isNotEqualTo(Optional.empty());
+        Optional<TeamParticipant> teamParticipant1 = teamParticipantRepository.findByUser(invitedUser1);
+        assertThat(teamParticipant1).isNotEqualTo(Optional.empty());
     }
 
     @Test
@@ -154,23 +156,24 @@ public class TeamTests {
         assertThat(teamParticipantRepository.findByUser(user)).isEqualTo(Optional.empty());
     }
 
-    @Test
-    public void acceptTeam() throws Exception {
-        //given
-        createTeamTest();
-        Team team = teamRepository.findByName("testTeam").orElseThrow();
-        User user = userRepository.findByEmail("invitedUser1").orElseThrow();
-
-        //when
-        teamService.acceptTeam(user.getId(), team.getId());
-
-        //then
-        TeamParticipant teamParticipant = teamParticipantRepository.findByUserAndTeamAndIsDeletedFalse(user, team)
-                .orElseThrow();
-
-        assertThat(teamParticipant.getUser().getId()).isEqualTo(user.getId());
-
-    }
+    // 그룹 초대 로직 변경으로 인해 사용 X
+//    @Test
+//    public void acceptTeam() throws Exception {
+//        //given
+//        createTeamTest();
+//        Team team = teamRepository.findByName("testTeam").orElseThrow();
+//        User user = userRepository.findByEmail("invitedUser1").orElseThrow();
+//
+//        //when
+//        teamService.acceptTeam(user.getId(), team.getId());
+//
+//        //then
+//        TeamParticipant teamParticipant = teamParticipantRepository.findByUserAndTeamAndIsDeletedFalse(user, team)
+//                .orElseThrow();
+//
+//        assertThat(teamParticipant.getUser().getId()).isEqualTo(user.getId());
+//
+//    }
 
     @Test
     public void leaveTeamTest() throws Exception {
@@ -187,32 +190,33 @@ public class TeamTests {
         assertThat(teamParticipant).isEqualTo(Optional.empty());
     }
 
-    @Test
-    public void updateTeamParticipantAuthorityTest() throws Exception {
-        //given
-        acceptTeam();
-        User hostUser = userRepository.findByEmail("testUser").orElseThrow();
-        User updateUser = userRepository.findByEmail("invitedUser1").orElseThrow();
-        Team team = teamRepository.findByName("testTeam").orElseThrow();
-        UserAuthDto userAuthDto = UserAuthDto.builder()
-                .userId(updateUser.getId())
-                .hasAuthority(true)
-                .build();
-        List<UserAuthDto> userAuthDtoList = new ArrayList<>();
-        userAuthDtoList.add(userAuthDto);
-
-        TeamParticipantAuthorityDto teamParticipantAuthorityDto = new TeamParticipantAuthorityDto().builder()
-                .teamId(team.getId())
-                .userAuthDtoList(userAuthDtoList)
-                .build();
-        //when
-        teamService.updateTeamParticipantAuthority(hostUser.getId(), teamParticipantAuthorityDto);
-
-        //then
-
-        TeamParticipant teamParticipant = teamParticipantRepository.findByUserAndTeamAndIsDeletedFalse(updateUser, team)
-                .orElseThrow();
-        assertThat(teamParticipant.getHasAuthority()).isEqualTo(true);
-
-    }
+    // 그룹 초대 로직 변경으로 인해 테스트 불가
+//    @Test
+//    public void updateTeamParticipantAuthorityTest() throws Exception {
+//        //given
+//        acceptTeam();
+//        User hostUser = userRepository.findByEmail("testUser").orElseThrow();
+//        User updateUser = userRepository.findByEmail("invitedUser1").orElseThrow();
+//        Team team = teamRepository.findByName("testTeam").orElseThrow();
+//        UserAuthDto userAuthDto = UserAuthDto.builder()
+//                .userId(updateUser.getId())
+//                .hasAuthority(true)
+//                .build();
+//        List<UserAuthDto> userAuthDtoList = new ArrayList<>();
+//        userAuthDtoList.add(userAuthDto);
+//
+//        TeamParticipantAuthorityDto teamParticipantAuthorityDto = new TeamParticipantAuthorityDto().builder()
+//                .teamId(team.getId())
+//                .userAuthDtoList(userAuthDtoList)
+//                .build();
+//        //when
+//        teamService.updateTeamParticipantAuthority(hostUser.getId(), teamParticipantAuthorityDto);
+//
+//        //then
+//
+//        TeamParticipant teamParticipant = teamParticipantRepository.findByUserAndTeamAndIsDeletedFalse(updateUser, team)
+//                .orElseThrow();
+//        assertThat(teamParticipant.getHasAuthority()).isEqualTo(true);
+//
+//    }
 }


### PR DESCRIPTION
# 💡 PR Summary - :recycle: 팀 생성 로직 변경(초대 없이 팀 구성)

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
팀 구성 시 따로 초대 보내는 로직 삭제

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
dev

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항

